### PR TITLE
Update train_cnn.py with replay_buffer argument

### DIFF
--- a/duckietown_rl/scripts/train_cnn.py
+++ b/duckietown_rl/scripts/train_cnn.py
@@ -50,7 +50,7 @@ max_action = float(env.action_space.high[0])
 # Initialize policy
 policy = DDPG(state_dim, action_dim, max_action, net_type="cnn")
 
-replay_buffer = ReplayBuffer()
+replay_buffer = ReplayBuffer(args.replay_buffer_max_size)
 
 # Evaluate untrained policy
 evaluations= [evaluate_policy(env, policy)]


### PR DESCRIPTION
In line 53
replay_buffer = ReplayBuffer() -->
replay_buffer = ReplayBuffer(args.replay_buffer_max_size)

avoid memory leak problem